### PR TITLE
Remove proc_macro feature.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate serde_json;
 extern crate crossbeam;


### PR DESCRIPTION
This is now on stable so the feature isn't required.