### PR TITLE
Add support for outputting branch coverage in LCOV format

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -122,7 +122,7 @@ pub fn output_lcov(results: CovResultIter) {
         // branch coverage information
         let mut branch_hit = 0;
         for (&(line, number), &taken) in &result.branches {
-            write!(writer, "BRDA:{},{},{},{}\n", line, 0, number, if taken {"1"} else {"-"}).unwrap();
+            write!(writer, "BRDA:{},{},{},{}\n", line, 0, number, if taken { "1" } else { "-" }).unwrap();
             if taken {
                 branch_hit = branch_hit + 1;
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -122,7 +122,7 @@ pub fn output_lcov(results: CovResultIter) {
         // branch coverage information
         let mut branch_hit = 0;
         for (&(line, number), &taken) in &result.branches {
-            write!(writer, "BRDA:{},{},{},{}\n", line, 0, number, if taken {taken} else {"-"}).unwrap();
+            write!(writer, "BRDA:{},{},{},{}\n", line, 0, number, if taken {"1"} else {"-"}).unwrap();
             if taken {
                 branch_hit = branch_hit + 1;
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -118,7 +118,19 @@ pub fn output_lcov(results: CovResultIter) {
             write!(writer, "FNF:{}\n", result.functions.len()).unwrap();
             write!(writer, "FNH:{}\n", result.functions.values().filter(|x| x.executed).count()).unwrap();
         }
-
+        
+        // branch coverage information
+        let mut branch_hit = 0;
+        for (&(line, number), &taken) in &result.branches {
+            write!(writer, "BRDA:{},{},{},{}\n", line, 0, number, if taken {taken} else {"-"}).unwrap();
+            if taken {
+                branch_hit = branch_hit + 1;
+            }
+        }
+        
+        write!(writer, "BRF:{}\n", result.branches.len()).unwrap();
+        write!(writer, "BRH:{}\n", branch_hit).unwrap();
+        
         for (line, execution_count) in &result.lines {
             write!(writer, "DA:{},{}\n", line, execution_count).unwrap();
         }


### PR DESCRIPTION
Fixes #39.
Added the code for outputting the branch coverage data in `lcov` format
- As in the link  [geninfo](http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) given, added the code after the FNH as finished.

The case when there are no branches,
`BRF, BRH` values will be `0`

Thank you for the valuable guidance.